### PR TITLE
Version update, removed printStackTrace usage, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-target
+target/
 .metadata/
+*.idea

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.micromata.jak</groupId>
 	<artifactId>JavaAPIforKml</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
+	<version>2.2.1_CODICE_1</version>
 	<name>a Java API for Kml</name>
 	<description>This is JavaAPIforKMml, Micromata's library for use with applications that want to parse, generate and operate on KML. It is an implementation of the OGC KML 2.2 standard. It is written entirely in Java and makes heavy use of JAXB.</description>
 	<packaging>jar</packaging>
@@ -130,6 +130,11 @@
 		</extensions>
 	</build>
 	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.1</version>
+		</dependency>
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-impl</artifactId>

--- a/src/main/java/de/micromata/opengis/kml/v_2_2_0/Kml.java
+++ b/src/main/java/de/micromata/opengis/kml/v_2_2_0/Kml.java
@@ -42,6 +42,8 @@ import de.micromata.opengis.kml.v_2_2_0.gx.Tour;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -79,6 +81,7 @@ import org.xml.sax.SAXException;
 @XmlRootElement(name = "kml", namespace = "http://www.opengis.net/kml/2.2")
 public class Kml implements Cloneable
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Kml.class);
 
     /**
      * <NetworkLinkControl>
@@ -683,7 +686,7 @@ public class Kml implements Cloneable
             m.marshal(this, outputstream);
             return true;
         } catch (JAXBException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Marshal exception: ", _x);;
             return false;
         }
     }
@@ -701,7 +704,7 @@ public class Kml implements Cloneable
             m.marshal(this, writer);
             return true;
         } catch (JAXBException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Marshal exception: ", _x);;
             return false;
         }
     }
@@ -722,7 +725,7 @@ public class Kml implements Cloneable
             m.marshal(this, contenthandler);
             return true;
         } catch (JAXBException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Marshal exception: ", _x);;
             return false;
         }
     }
@@ -740,7 +743,7 @@ public class Kml implements Cloneable
             m.marshal(this, System.out);
             return true;
         } catch (JAXBException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Marshal exception: ", _x);;
             return false;
         }
     }
@@ -783,7 +786,7 @@ public class Kml implements Cloneable
             unmarshaller.setSchema(schema);
             return true;
         } catch (SAXException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Validate exception: ", _x);;
         }
         return false;
     }
@@ -807,13 +810,13 @@ public class Kml implements Cloneable
             Kml jaxbRootElement = ((Kml) unmarshaller.unmarshal(saxSource));
             return jaxbRootElement;
         } catch (SAXException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         } catch (ParserConfigurationException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         } catch (JAXBException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         } catch (FileNotFoundException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         }
         return null;
     }
@@ -846,11 +849,11 @@ public class Kml implements Cloneable
             Kml jaxbRootElement = ((Kml) unmarshaller.unmarshal(saxSource));
             return jaxbRootElement;
         } catch (SAXException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         } catch (ParserConfigurationException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         } catch (JAXBException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         }
         return null;
     }
@@ -871,11 +874,11 @@ public class Kml implements Cloneable
             Kml jaxbRootElement = ((Kml) unmarshaller.unmarshal(saxSource));
             return jaxbRootElement;
         } catch (SAXException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         } catch (ParserConfigurationException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         } catch (JAXBException _x) {
-            _x.printStackTrace();
+            LOGGER.debug("Unmarshal exception: ", _x);;
         }
         return null;
     }


### PR DESCRIPTION
@clockard @gordocanchola @shaundmorris @rzwiefel @AzGoalie @ahoffer 

When the DDF KmlInputTransformer attempted to unmarshal an xml product that was not kml, the resulting exception was printed to the karaf console. This change prevents that scenario from happening.

https://github.com/codice/ddf/blob/master/catalog/spatial/kml/spatial-kml-transformer/src/main/java/org/codice/ddf/spatial/kml/transformer/KmlInputTransformer.java#L89